### PR TITLE
feat: add colorful.kst v2 to verified addresses

### DIFF
--- a/src/__data__/verified-addresses.json
+++ b/src/__data__/verified-addresses.json
@@ -31,5 +31,9 @@
     "label": "PG231's LP",
     "description": "Liquidity pools on SwitchCraft operated by PG231."
   },
-  "kxxxxxxxxk": { "label": "X" }
+  "kxxxxxxxxk": { "label": "X" },
+  "ka60tvi5xe": {
+    "label": "Colorful",
+    "description": "Store with colored blocks on SwitchCraft operated by znepb."
+  }
 }


### PR DESCRIPTION
I know my addition of Snowflake was rejected, but I was told that wallets that hold players' balances are given the verified status. colorful.kst v2 has this feature. Users can deposit Krist into their accounts via external sources because purchases can only be made in-game. Adding colorful.kst to verified addresses would make this easier. Krist can also be held for future purchases, as colorful.kst v2 supports fractional Krist.